### PR TITLE
Update package.json nax-ccuilib repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/node": "^20.4.9",
     "esbuild": "^0.18.15",
-    "nax-ccuilib": "conorlawton/CCUILib",
+    "nax-ccuilib": "conorlawton/nax-ccuilib",
     "nodemon": "^3.0.1",
     "typescript": "^5.1.6",
     "ultimate-crosscode-typedefs": "github:CCDirectLink/ultimate-crosscode-typedefs"


### PR DESCRIPTION
Looks like it's outdated, `pnpm install` didn't work for me because of it.
