### PR TITLE
Quest Hub AP icons + remove level from obscured equipment

### DIFF
--- a/src/patches/quest.ts
+++ b/src/patches/quest.ts
@@ -316,6 +316,7 @@ export function patch(plugin: MwRandomizer) {
 
 					if (sc.multiworld.questSettings.hideIcon) {
 						itemInfo.icon = "ap-logo";
+						itemInfo.level = 0;
 					}
 				}
 

--- a/src/patches/quest.ts
+++ b/src/patches/quest.ts
@@ -192,7 +192,9 @@ export function patch(plugin: MwRandomizer) {
 				let currentIcon = rewardIcons[i].gui;
 				if ('font' in currentIcon) {
 					this.rewards.hook.removeChildHookByIndex(i);
+				// @ts-ignore
 				} else if (currentIcon.offsetX) {
+					// @ts-ignore
 					switch (currentIcon.offsetX) {
 						case 472: // Experience
 							apIconX += 17;
@@ -207,6 +209,7 @@ export function patch(plugin: MwRandomizer) {
 				}
 			}
 
+			// @ts-ignore
 			let quest = sc.quests.getStaticQuest(questId);
 			let mwQuest = getRawQuestFromQuestId(questId);
 			if (mwQuest == undefined) return;
@@ -275,7 +278,6 @@ export function patch(plugin: MwRandomizer) {
 				);
 
 				if (toHint.length > 0) {
-					// @ts-ignore
 					sc.multiworld.client.locations.scout(ap.CREATE_AS_HINT_MODE.HINT_ONLY_NEW, ...toHint);
 				}
 			}

--- a/src/patches/quest.ts
+++ b/src/patches/quest.ts
@@ -219,7 +219,22 @@ export function patch(plugin: MwRandomizer) {
 				const item: ap.NetworkItem = sc.multiworld.locationInfo[mwid];
 
 				let icon = "ap-logo";
-				if (sc.multiworld.options.hiddenQuestRewardMode == "show_all" || !quest.hideRewards) {
+				let useGenericIcon = true;
+				const hiddenQuestRewardMode = sc.multiworld.options.hiddenQuestRewardMode;
+				if (hiddenQuestRewardMode == "show_all") {
+					useGenericIcon = false;
+				} else if (
+					hiddenQuestRewardMode == "hide_all" ||
+					(hiddenQuestRewardMode == "vanilla" && quest.hideRewards)
+				) {
+					if (sc.multiworld.options.hiddenQuestObfuscationLevel == "hide_all") {
+						useGenericIcon = true;
+					}
+				} else {
+					useGenericIcon = false;
+				}
+
+				if (!useGenericIcon) {
 					const itemInfo = plugin.getItemInfo(item);
 					icon = itemInfo.icon;
 				}

--- a/src/patches/quest.ts
+++ b/src/patches/quest.ts
@@ -221,6 +221,11 @@ export function patch(plugin: MwRandomizer) {
 					icon = itemInfo.icon;
 				}
 
+				if (icon.startsWith("ap-")) {
+					apIconX -= 1;
+				}
+
+				// console.log(icon);
 				const apIcon = new sc.TextGui(`\\i[${icon}]`);
 				apIcon.setPos(apIconX, 10);
 				this.rewards.addChildGui(apIcon);

--- a/src/patches/quest.ts
+++ b/src/patches/quest.ts
@@ -243,7 +243,6 @@ export function patch(plugin: MwRandomizer) {
 					apIconX -= 1;
 				}
 
-				// console.log(icon);
 				const apIcon = new sc.TextGui(`\\i[${icon}]`);
 				apIcon.setPos(apIconX, 10);
 				this.rewards.addChildGui(apIcon);

--- a/src/patches/quest.ts
+++ b/src/patches/quest.ts
@@ -186,6 +186,64 @@ export function patch(plugin: MwRandomizer) {
 		}
 	});
 
+	sc.QuestHubListEntry.inject({
+		init(questName: string, tabIndex: number) {
+			this.parent(questName, tabIndex);
+
+			let rewardIcons = this.rewards.hook.children;
+			let x = 10;
+			for (let i = rewardIcons.length - 1; i >= 1; i--) {
+				let icon = rewardIcons[i].gui;
+				// Remove any vanilla item reward
+				if ('font' in icon) {
+					this.rewards.hook.removeChildHookByIndex(i);
+				} else if (icon.offsetX) {
+					// Offset x by icon margins
+					switch (icon.offsetX) {
+						case 472: // Experience
+							x += 17;
+							break;
+						case 593: // Circuit Points
+							x += 13;
+							break;
+						case 488: // Credits
+							x += 15;
+							break;
+					}
+				}
+			}
+
+			let quest = sc.quests.getStaticQuest(questName);
+			// FIXME: Wet code
+			let mwQuest = quests[questName];
+			if (
+				mwQuest === undefined ||
+				mwQuest.mwids === undefined ||
+				mwQuest.mwids.length === 0 ||
+				sc.multiworld.locationInfo[mwQuest.mwids[0]] === undefined
+			) {
+				return;
+			}
+
+			for (let i = 0; i < mwQuest.mwids.length; i++) {
+				const mwid: number = mwQuest.mwids[i]
+				const item: ap.NetworkItem = sc.multiworld.locationInfo[mwid];
+
+				let icon = "ap-logo";
+				if (sc.multiworld.options.hiddenQuestRewardMode == "show_all" || (!quest.hideRewards)) {
+					const itemInfo = plugin.getItemInfo(item);
+					icon = itemInfo.icon;
+				}
+
+				const apIcon = new sc.TextGui(`\\i[${icon}]`);
+				apIcon.setPos(x, 10);
+				this.rewards.addChildGui(apIcon);
+				x += 16
+			}
+
+		}
+	});
+
 	sc.MultiWorldQuestItemBox = ig.GuiElementBase.extend({
 		gfx: new ig.Image("media/gui/menu.png"),
 		init(


### PR DESCRIPTION
AP icons for the Quest Hub have been added! It supports multiworld items, and items from CrossCode too.
![image](https://github.com/user-attachments/assets/658806f0-fd8a-4c5a-954d-336d02d6c570)

If all icons are obscured, it looks like this:
![image](https://github.com/user-attachments/assets/da86f8b3-de93-4a0a-ae4b-8b3a26905447)

Equipment is now properly obscured (this one is a lvl. 1 Broken Deck):
![image](https://github.com/user-attachments/assets/a127ade0-d079-467d-967f-d771ef2e815f)

Also cleaned up some of the code a little bit.