### PR TITLE
Fix hard crash when no save file is available

### DIFF
--- a/src/patches/login.ts
+++ b/src/patches/login.ts
@@ -192,17 +192,19 @@ export function patch(plugin: MwRandomizer) {
 			this.parent();
 
 			let continueButton: sc.ButtonGui = this.namedButtons["continue"];
+			if (continueButton) {
+				let oldContinueCallback = continueButton.onButtonPress;
 
-			let oldContinueCallback = continueButton.onButtonPress;
+				continueButton.onButtonPress = () => {
+					let slot: ig.SaveSlot = ig.storage.getSlot(ig.storage.lastUsedSlot);
+					let mw = slot.data.vars.storage.mw;
+					sc.multiworld.spawnLoginGui(mw?.connectionInfo, mw, oldContinueCallback, () => {
+						sc.menu.exitCallback = oldContinueCallback;
+						sc.model.enterPrevSubState();
+					});
+				};
+			}
 
-			continueButton.onButtonPress = () => {
-				let slot: ig.SaveSlot = ig.storage.getSlot(ig.storage.lastUsedSlot);
-				let mw = slot.data.vars.storage.mw;
-				sc.multiworld.spawnLoginGui(mw?.connectionInfo, mw, oldContinueCallback, () => {
-					sc.menu.exitCallback = oldContinueCallback;
-					sc.model.enterPrevSubState();
-				});
-			};
 
 			let newGameButton: sc.ButtonGui = this.namedButtons["start"];
 


### PR DESCRIPTION
`sc.TitleScreenButtonGui#namedButtons.continue` is only created when `ig.storage.hasSaves() == true`,  
so when no save file is available, the game would hard crash at startup.