### PR TITLE
Closed Gaia options

### DIFF
--- a/data/in/chests.json
+++ b/data/in/chests.json
@@ -5690,7 +5690,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10.Grove"
+				"open": "open10.Mid"
 			},
 			"reward": [
 				[

--- a/data/in/chests.json
+++ b/data/in/chests.json
@@ -4700,7 +4700,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -4726,7 +4726,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -4752,7 +4752,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4771,7 +4771,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4790,7 +4790,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4809,7 +4809,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4828,7 +4828,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4854,7 +4854,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4880,7 +4880,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4899,7 +4899,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4918,7 +4918,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4937,7 +4937,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -4963,7 +4963,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "28",
-				"open": "open10"
+				"open": "open10.Mid"
 			},
 			"condition": [
 				[
@@ -4994,7 +4994,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -5013,7 +5013,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5032,7 +5032,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5051,7 +5051,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5070,7 +5070,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5089,7 +5089,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5108,7 +5108,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5127,7 +5127,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5146,7 +5146,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5165,7 +5165,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "28",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5196,7 +5196,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "28",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5227,7 +5227,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "28",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5258,7 +5258,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5277,7 +5277,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5296,7 +5296,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5322,7 +5322,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5341,7 +5341,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5360,7 +5360,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5379,7 +5379,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5405,7 +5405,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5424,7 +5424,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5443,7 +5443,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5462,7 +5462,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5481,7 +5481,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5500,7 +5500,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Infested"
 			},
 			"reward": [
 				[
@@ -5519,7 +5519,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -5545,7 +5545,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -5559,6 +5559,11 @@
 					"item",
 					"Wave",
 					1
+				],
+				[
+					"region",
+					"open",
+					"open10.Right"
 				]
 			]
 		},
@@ -5571,7 +5576,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -5585,6 +5590,11 @@
 					"item",
 					"Wave",
 					1
+				],
+				[
+					"region",
+					"open",
+					"open10.Right"
 				]
 			]
 		},
@@ -5597,7 +5607,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -5616,7 +5626,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -5635,7 +5645,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5661,7 +5671,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5680,7 +5690,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5706,7 +5716,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"reward": [
 				[
@@ -5763,7 +5773,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -5782,7 +5792,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -5801,7 +5811,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Mid"
 			},
 			"reward": [
 				[
@@ -5820,7 +5830,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Mid"
 			},
 			"reward": [
 				[
@@ -5839,7 +5849,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Mid"
 			},
 			"reward": [
 				[
@@ -5865,7 +5875,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Mid"
 			},
 			"reward": [
 				[
@@ -5884,7 +5894,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -5910,7 +5920,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -5929,7 +5939,7 @@
 			"clearance": "Silver",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -5948,7 +5958,7 @@
 			"clearance": "Gold",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"condition": [
 				[ "item", "Wave" ]
@@ -5970,7 +5980,7 @@
 			"clearance": "Bronze",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -5989,7 +5999,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -6008,7 +6018,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -6459,7 +6469,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"reward": [
 				[
@@ -6523,7 +6533,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Right"
 			},
 			"condition": [
 				[
@@ -6744,7 +6754,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -6801,7 +6811,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"reward": [
 				[
@@ -6877,7 +6887,7 @@
 			"clearance": "Default",
 			"region": {
 				"linear": "26",
-				"open": "open10"
+				"open": "open10.Left"
 			},
 			"condition": [
 				[

--- a/data/in/cutscenes.json
+++ b/data/in/cutscenes.json
@@ -368,6 +368,36 @@
 			"reward": [
 				[ "sp" ]
 			]
+		},
+		"Apollo Duel East Pass": {
+			"location": {
+				"area": "jungle",
+				"map": "jungle.path-01-entrance",
+				"mapId": 813,
+				"path": ".settings.event.49" 
+			},
+			"region": {
+				"linear": "30",
+				"open": "open10" 
+			},
+			"reward": [
+				[ "item", "East Gaia Pass", 1 ]
+			]
+		},
+		"Apollo Duel West Pass": {
+			"location": {
+				"area": "jungle",
+				"map": "jungle.path-01-entrance",
+				"mapId": 813,
+				"path": ".settings.event.48" 
+			},
+			"region": {
+				"linear": "30",
+				"open": "open10" 
+			},
+			"reward": [
+				[ "item", "West Gaia Pass", 1 ]
+			]
 		}
 	}
 }

--- a/data/in/item-pools/required.json
+++ b/data/in/item-pools/required.json
@@ -134,6 +134,14 @@
 				"quantity": 1
 			},
 			{
+				"item": ["item", "East Gaia Pass"],
+				"quantity": 1
+			},
+			{
+				"item": ["item", "West Gaia Pass"],
+				"quantity": 1
+			},
+			{
 				"item": ["item", "Old Dojo Key"],
 				"quantity": 1
 			},

--- a/data/in/items.json
+++ b/data/in/items.json
@@ -89,6 +89,12 @@
 		"Dungeon Heart": {
 			"id": 18
 		},
+		"West Gaia Pass": {
+			"id": 19
+		},
+		"East Gaia Pass": {
+			"id": 20
+		},
 		"Rookiehat": {
 			"id": 23
 		},

--- a/data/in/quests-qr.json
+++ b/data/in/quests-qr.json
@@ -847,6 +847,7 @@
 				"linear": "23",
 				"open": "open10"
 			},
+			"condition": [[ "region", "open", "open10.Grove" ]],
 			"reward": [
 				[ "item", "Virus Root", 4 ],
 				[ "item", "Stout Backplate", 2 ]
@@ -907,7 +908,8 @@
 			},
 			"condition": [
 				[ "item", "Cold" ],
-				[ "item", "Heat" ]
+				[ "item", "Heat" ],
+				[ "region", "open", "open10.Right" ]
 			],
 			"reward": [
 				[ "item", "Moon Fruit", 5 ],
@@ -938,6 +940,7 @@
 				"linear": "23",
 				"open": "open10"
 			},
+			"condition": [[ "region", "open", "open10.Grove" ]],
 			"reward": [
 				[ "item", "Green Risotto", 3 ],
 				[ "item", "Wrap Roll", 3 ],
@@ -969,7 +972,8 @@
 				"open": "open10"
 			},
 			"condition": [
-				[ "item", "Wave", 1 ]
+				[ "item", "Wave", 1 ],
+				[ "region", "open", "open10.Infested" ]
 			]
 		},
 		"Pumpkin Land Superfun": {
@@ -978,6 +982,7 @@
 				"linear": "23",
 				"open": "open10"
 			},
+			"condition": [[ "region", "open", "open10.Infested" ]],
 			"reward": [
 				[ "item", "Scarecrown", 1 ]
 			]
@@ -989,7 +994,8 @@
 				"open": "open10"
 			},
 			"condition": [
-				[ "item", "Broken Deck", 1 ]
+				[ "item", "Broken Deck", 1 ],
+				[ "region", "open", "open10.Grove" ]
 			]
 		},
 		"Gaia's Garden Trailblazing": {
@@ -1016,7 +1022,7 @@
 			"questid": "trailblaze-jungle-2",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Mid"
 			}
 		},
 		"Gaia's Garden Landmarks": {
@@ -1024,7 +1030,11 @@
 			"region": {
 				"linear": "23",
 				"open": "open10"
-			}
+			},
+			"condition": [
+				[ "region", "open", "open10.Grove" ],
+				[ "region", "open", "open10.Infested" ]
+			]
 		},
 		"Gaia's Garden Data Probe": {
 			"questid": "trailblaze-jungle-4",
@@ -1033,14 +1043,15 @@
 				"open": "open10"
 			},
 			"condition": [
-				[ "item", "Wave", 1 ]
+				[ "item", "Wave", 1 ],
+				[ "region", "open", "open10.Grove" ]
 			]
 		},
 		"Turret Defense Challenge 1": {
 			"questid": "jungleAdv-turret_defense_challenge-1",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"condition": [
 				[ "quest", "Turret Defense" ]
@@ -1053,7 +1064,7 @@
 			"questid": "jungleAdv-turret_defense_challenge-2",
 			"region": {
 				"linear": "23",
-				"open": "open10"
+				"open": "open10.Grove"
 			},
 			"condition": [
 				[ "quest", "An Original Idea" ]

--- a/data/in/quests-qr.json
+++ b/data/in/quests-qr.json
@@ -994,8 +994,7 @@
 				"open": "open10"
 			},
 			"condition": [
-				[ "item", "Broken Deck", 1 ],
-				[ "region", "open", "open10.Grove" ]
+				[ "item", "Broken Deck", 1 ]
 			]
 		},
 		"Gaia's Garden Trailblazing": {

--- a/data/in/regions.json
+++ b/data/in/regions.json
@@ -438,20 +438,19 @@
 					"from": "open10",
 					"to": "open10.Left",
 					"condition": [
-						["or", 
-							[ "var", "closedGaia", "false" ], 
-							["and", [ "item", "West Gaia Pass", 1 ], [ "var", "closedGaia", "true" ]]
+							[ "or", 
+								[ "var", "closedGaia", "on", false ], 
+								[ "and", [ "item", "West Gaia Pass", 1 ], [ "var", "closedGaia", "on" ]]
+							]
 						]
-
-					]
 				},
 				{
 					"from": "open10",
 					"to": "open10.Right",
 					"condition": [
-						["or", 
-							[ "var", "closedGaia", "false" ], 
-							["and", [ "item", "East Gaia Pass", 1 ], [ "var", "closedGaia", "true" ]]
+						[ "or", 
+							[ "var", "closedGaia", "on", false ], 
+							[ "and", [ "item", "East Gaia Pass", 1 ], [ "var", "closedGaia", "on" ]]
 						]
 					]
 				},
@@ -459,17 +458,22 @@
 					"from": "open10",
 					"to": "open10.Mid",
 					"condition": [
-						["or", [ "item", "East Gaia Pass", 1 ], [ "item", "West Gaia Pass", 1 ]],
-						[ "var", "closedGaia", "true" ]
+						[ "or", 
+							[ "and", 
+								[ "or", [ "item", "East Gaia Pass", 1 ], [ "item", "West Gaia Pass", 1 ]],
+								[ "var", "closedGaia", "on" ]
+							],
+							[ "var", "closedGaia", "on", false ] 
+						]
 					]
 				},
 				{
 					"from": "open10.Left",
 					"to": "open10.Grove",
 					"condition": [
-						["or", 
-							[ "var", "closedGaia", "false" ], 
-							["and", [ "item", "Azure Drop Shade", 1 ], [ "var", "closedGaia", "true" ]]
+						[ "or", 
+							[ "var", "closedGaia", "full", false ], 
+							[ "and", [ "item", "Azure Drop Shade", 1 ], [ "var", "closedGaia", "full" ]]
 						]
 					]
 				},
@@ -477,9 +481,9 @@
 					"from": "open10.Right",
 					"to": "open10.Infested",
 					"condition": [
-						["or", 
-							[ "var", "closedGaia", "false" ], 
-							["and", [ "item", "Purple Bolt Shade", 1 ], [ "var", "closedGaia", "true" ]]
+						[ "or", 
+							[ "var", "closedGaia", "full", false ], 
+							[ "and", [ "item", "Purple Bolt Shade", 1 ], [ "var", "closedGaia", "full"  ]]
 						]
 					]
 				},
@@ -507,7 +511,7 @@
 					]
 				},
 				{
-					"from": "open10",
+					"from": "open10.Left",
 					"to": "open14.2",
 					"condition": [
 						[ "item", "So'najiz Key", 3 ],

--- a/data/in/regions.json
+++ b/data/in/regions.json
@@ -436,6 +436,55 @@
 				},
 				{
 					"from": "open10",
+					"to": "open10.Left",
+					"condition": [
+						["or", 
+							[ "var", "closedGaia", "false" ], 
+							["and", [ "item", "West Gaia Pass", 1 ], [ "var", "closedGaia", "true" ]]
+						]
+
+					]
+				},
+				{
+					"from": "open10",
+					"to": "open10.Right",
+					"condition": [
+						["or", 
+							[ "var", "closedGaia", "false" ], 
+							["and", [ "item", "East Gaia Pass", 1 ], [ "var", "closedGaia", "true" ]]
+						]
+					]
+				},
+				{
+					"from": "open10",
+					"to": "open10.Mid",
+					"condition": [
+						["or", [ "item", "East Gaia Pass", 1 ], [ "item", "West Gaia Pass", 1 ]],
+						[ "var", "closedGaia", "true" ]
+					]
+				},
+				{
+					"from": "open10.Left",
+					"to": "open10.Grove",
+					"condition": [
+						["or", 
+							[ "var", "closedGaia", "false" ], 
+							["and", [ "item", "Azure Drop Shade", 1 ], [ "var", "closedGaia", "true" ]]
+						]
+					]
+				},
+				{
+					"from": "open10.Right",
+					"to": "open10.Infested",
+					"condition": [
+						["or", 
+							[ "var", "closedGaia", "false" ], 
+							["and", [ "item", "Purple Bolt Shade", 1 ], [ "var", "closedGaia", "true" ]]
+						]
+					]
+				},
+				{
+					"from": "open10.Right",
 					"to": "open13.1",
 					"condition": [
 						[ "item", "Zir'vitar Key", 2 ],
@@ -450,7 +499,7 @@
 					]
 				},
 				{
-					"from": "open10",
+					"from": "open10.Left",
 					"to": "open14.1",
 					"condition": [
 						[ "item", "So'najiz Key", 1 ],

--- a/data/in/vars.json
+++ b/data/in/vars.json
@@ -26,6 +26,10 @@
 					[ "item", "Red Flame Shade" ]
 				]
 			]
+		},
+		"closedGaia": {
+			"minimal": [],
+			"full": []
 		}
 	}
 }


### PR DESCRIPTION
Adds Closed Gaia support, modifies base Open logic to support the new regions (branching from Open 10):
- Divides Gaia's Garden into 2 new branching regions, Gaia East and Gaia West. Requires East and West Gaia Passes to open these regions (obtainable from Apollo Duel on Gaia's Garden Entrance). 
- Further locks available by setting Closed Gaia to 'full', locking Grove and Infested areas with Azure Drop and Purple Bolt Shades.