### PR TITLE
Update the regions to allow hub connections

### DIFF
--- a/data/in/regions.json
+++ b/data/in/regions.json
@@ -327,6 +327,14 @@
 					"condition": [
 						[ "item", "Blue Ice Shade", 1 ]
 					]
+				},				
+				{
+					"from": "open2",
+					"to": "open5",
+					"condition": [
+						[ "item", "Blue Ice Shade", 1 ],
+						[ "var", "rhombusHubUnlock" ]
+					]
 				},
 				{
 					"from": "open5",
@@ -415,16 +423,17 @@
 				},
 				{
 					"from": "open9",
-					"to": "open9.1",
+					"to": "open10",
 					"condition": [
 						[ "item", "Green Seed Shade", 1 ]
 					]
 				},
 				{
-					"from": "open9",
+					"from": "open2",
 					"to": "open10",
 					"condition": [
-						[ "item", "Green Seed Shade", 1 ]
+						[ "item", "Green Seed Shade", 1 ],
+						[ "var", "rhombusHubUnlock" ]
 					]
 				},
 				{
@@ -518,6 +527,14 @@
 					"to": "open16",
 					"condition": [
 						[ "item", "Star Shade", 1 ]
+					]
+				},
+				{
+					"from": "open2",
+					"to": "open16",
+					"condition": [
+						[ "item", "Star Shade", 1 ],
+						[ "var", "rhombusHubUnlock" ]
 					]
 				},
 				{


### PR DESCRIPTION
- Added region connections from Rhombus Square Hub to Gaia's Garden, Sapphire Ridge, and Maroon Valley. 

- Removed unused region 9.1