### PR TITLE
Remove Blue Ice Shade RH3 quests

### DIFF
--- a/data/in/quests-qr.json
+++ b/data/in/quests-qr.json
@@ -1176,7 +1176,6 @@
 				"open": "open9"
 			},
 			"condition": [
-				[ "item", "Blue Ice Shade", 1 ],
 				[ "item", "Red Flame Shade", 1 ],
 				[ "item", "Heat", 1 ],
 				[ "item", "Cold", 1 ],
@@ -1263,7 +1262,6 @@
 			},
 			"condition": [
 				[ "item", "Red Flame Shade", 1 ],
-				[ "item", "Blue Ice Shade", 1 ],
 				[ "item", "Heat", 1 ],
 				[ "item", "Cold", 1 ],
 				[ "quest", "Bull Grab" ]


### PR DESCRIPTION
- Remove Blue Ice Shade requirement for "New Metal" quest
- Remove Blue Ice Shade requirement for "Points of Power" quest