### PR TITLE
Add support for different goals

### DIFF
--- a/assets/data/maps/jungle/dng/tree-expo-space.json.patch
+++ b/assets/data/maps/jungle/dng/tree-expo-space.json.patch
@@ -1,0 +1,28 @@
+[
+	{
+		"type": "ENTER",
+		"index": ["entities"]
+	},
+	{
+		"type": "ADD_ARRAY_ELEMENT",
+		"content": {
+			"type": "EventTrigger",
+			"x": 0,
+			"y": 0,
+			"level": 3,
+			"settings": {
+				"name": "Goal",
+				"eventType": "PARALLEL",
+				"triggerType": "ONCE_PER_ENTRY",
+				"startCondition": "true",
+				"endCondition": "false",
+				"event": [
+					{
+						"type": "MW_GOAL_COMPLETED",
+						"goal": "monkey"
+					}
+				]
+			}
+		}
+	}
+]

--- a/data/in/regions.json
+++ b/data/in/regions.json
@@ -247,7 +247,11 @@
 			],
 			"exclude": [ "1" ],
 			"start": "2",
-			"goal": "32"
+			"goals": {
+				"creator": {
+					"region": "32"
+				}
+			}
 		},
 		"open": {
 			"connections": [
@@ -611,10 +615,13 @@
 					"condition": [
 						["var", "vwPassage"]
 					]
-				},
-				{
-					"from": "open16.1",
-					"to": "open19",
+				}
+			],
+			"exclude": [ "open1" ],
+			"start": "open2",
+			"goals": {
+				"creator": {
+					"region": "open16.1",
 					"condition": [
 						[ "item", "Heat", 1 ],
 						[ "item", "Cold", 1 ],
@@ -622,11 +629,11 @@
 						[ "item", "Wave", 1 ],
 						[ "var", "vtShadeLock" ]
 					]
+				},
+				"monkey": {
+					"region": "open15.3"
 				}
-			],
-			"exclude": [ "open1" ],
-			"start": "open2",
-			"goal": "open19"
+			}
 		}
 	}
 }

--- a/src/patches/event.ts
+++ b/src/patches/event.ts
@@ -57,13 +57,15 @@ export function patch(plugin: MwRandomizer) {
 
 	ig.EVENT_STEP.MW_GOAL_COMPLETED = ig.EventStepBase.extend({
 		init(settings) {
-			// In the future, goal will only update client status if it checks off
-			// a specific goal specified by their yaml. For now, there's only one
-			// goal.
 			this.goal = settings.goal;
 		},
 		start() {
-			sc.multiworld.client.goal();
+			if (
+				sc.multiworld.options.goal === undefined && this.goal === "creator" ||
+				sc.multiworld.options.goal === this.goal
+			) {
+				sc.multiworld.client.goal();
+			}
 		}
 	});
 }

--- a/src/types/multiworld-model.ts
+++ b/src/types/multiworld-model.ts
@@ -78,8 +78,10 @@ declare global {
 			}
 
 			export type MultiworldOptions = {
+				goal: string,
 				vtShadeLock: boolean | number,
 				meteorPassage: boolean,
+				closedGaia: number,
 				vtSkip: boolean,
 				keyrings: number[],
 				questRando: boolean,


### PR DESCRIPTION
This PR adds configurable goals to CCMWR. Creator Goal remains the same logically, although it is structured slightly differently.
As well, this proposal adds Monkey goal, which is to defeat Son of the East at the top of the Grand Krys'kajo.