### PR TITLE
Various UI enhancements

### DIFF
--- a/assets/data/lang/sc/gui.en_US.json.patch
+++ b/assets/data/lang/sc/gui.en_US.json.patch
@@ -8,6 +8,9 @@
 				"apConnection": "Connection Info",
 				"apTextClient": "AP Text Client",
 				"apGameInfoMenu": "AP Game Info"
+			},
+			"new-game": {
+				"modifyOptions": "Modify Options"
 			}
 		},
 		"title-screen": {

--- a/src/patches/gui-misc.ts
+++ b/src/patches/gui-misc.ts
@@ -400,7 +400,12 @@ export function patch(plugin: MwRandomizer) {
 			this.buttongroup.addFocusGui(this.connect, 0, this.fields.length);
 
 			this.disconnect = new sc.ButtonGui("Disconnect", sc.BUTTON_MENU_WIDTH);
-			this.disconnect.onButtonPress = () => { sc.multiworld.disconnect() };
+			this.disconnect.onButtonPress = () => {
+				sc.multiworld.disconnect();
+				if (!sc.model.isGame()) {
+					sc.multiworld.unsetVars();
+				}
+			};
 			this.disconnect.setPos(sc.BUTTON_MENU_WIDTH + this.hSpacer);
 			this.disconnect.data = ig.lang.get("sc.gui.mw.connection-menu.disconnect");
 			this.buttongroup.addFocusGui(this.disconnect, 1, this.fields.length);

--- a/src/patches/login.ts
+++ b/src/patches/login.ts
@@ -213,7 +213,7 @@ export function patch(plugin: MwRandomizer) {
 			newGameButton.onButtonPress = () => {
 				sc.menu.setDirectMode(true, sc.MENU_SUBMENU.AP_TEXT_CLIENT);
 				sc.menu.exitCallback = () => {
-					if (sc.multiworld.client.authenticated) {
+					if (sc.multiworld.client.authenticated && sc.newgame.active) {
 						// unset New Game Plus to get the behavior I want from the callback.
 						let oldNGP = this._newGamePlus;
 						this._newGamePlus = false;

--- a/src/patches/new-game.ts
+++ b/src/patches/new-game.ts
@@ -8,6 +8,10 @@ declare global {
 			apGui: sc.NewGameModeDialogButton;
 			oldCallback: this["callback"];
 		}
+
+		interface NewGameToggleSet {
+			setName: string;
+		}
 	}
 }
 
@@ -52,6 +56,11 @@ export function patch(plugin: MwRandomizer) {
 	});
 
 	sc.NewGameToggleSet.inject({
+		init(set, list, yOffset, listIndex, counter) {
+			this.parent(set, list, yOffset, listIndex, counter);
+			this.setName = set;
+		},
+
 		updateActiveState(
 			totalPoints: number,
 			newGameCost: number,
@@ -60,7 +69,10 @@ export function patch(plugin: MwRandomizer) {
 			this.parent(totalPoints, newGameCost, remainingCredits);
 
 			for (const button of this.buttons) {
-				if (button.data.id == "rhombus-start") {
+				if (
+					button.data.id == "rhombus-start" ||
+					this.setName == "carry-over" && !sc.menu.newGameViewMode && sc.model.isGame()
+				) {
 					button.setActive(false);
 				}
 			}

--- a/src/patches/new-game.ts
+++ b/src/patches/new-game.ts
@@ -12,6 +12,12 @@ declare global {
 }
 
 export function patch(plugin: MwRandomizer) {
+	sc.TrophyManager.inject({
+		getTotalPoints() {
+			return 1e9;
+		}
+	});
+
 	sc.NewGamePlusModel.inject({
 		options: { "rhombus-start": true },
 		onReset() {

--- a/src/patches/new-game.ts
+++ b/src/patches/new-game.ts
@@ -29,7 +29,25 @@ export function patch(plugin: MwRandomizer) {
 	sc.NewGamePlusMenu.inject({
 		init() {
 			this.parent();
-			this.button.setActive(sc.newgame.hasAnyOptions());
+			if (!sc.menu.newGameViewMode && sc.model.isGame()) {
+				// this.button.setActive(sc.newgame.hasAnyOptions());
+				const oldWidth = this.button.hook.size.x;
+				this.button.setText(
+					"\\i[help2]" + ig.lang.get("sc.gui.menu.new-game.modifyOptions")
+				)
+				const newWidth = this.button.hook.size.x;
+				this.button.hook.pos.x -= (newWidth - oldWidth) / 2;
+				this.button.setActive(true);
+			}
+		},
+
+		onBeginButtonPressed() {
+			if (!sc.menu.newGameViewMode && sc.model.isGame()) {
+				sc.menu.popBackCallback();
+				sc.menu.popMenu();
+			} else {
+				this.parent();
+			}
 		},
 	});
 

--- a/src/patches/text-client.ts
+++ b/src/patches/text-client.ts
@@ -468,6 +468,7 @@ export function patch(plugin: MwRandomizer) {
 			}
 
 			this.buttons.gameInfo.setActive(!!sc.multiworld.options);
+			this.buttons.newGamePlus.setActive(!!sc.multiworld.options);
 
 			this.addObservers();
 


### PR DESCRIPTION
This PR adds more intentionality to the flow when logging into a new game.

Checklist for this PR:
- [x] Allow any NG+ options to be selected regardless of previous save file completion.
- [x] No longer load into a game without NG+ enabled when exiting the text client menu.
- [x] Add a clearer indication that NG+ options can be edited from the New Game Plus menu found in the Archipelago menu.
- [x] Block out "carry over" section of NG+ to indicate that they cannot be modified.
- [x] Stop the game from blocking infinitely when entering new login information after previously entering login information and disconnecting.