### PR TITLE
Add sanity checking to prevent connecting to incorrect slots

### DIFF
--- a/assets/data/lang/sc/gui.en_US.json.patch
+++ b/assets/data/lang/sc/gui.en_US.json.patch
@@ -35,6 +35,13 @@
 				"connect": "Connect to the multiworld using these details.",
 				"disconnect": "Disconnect from the multiworld if connected."
 			},
+			"login": {
+				"failures": {
+					"gen-version": "Cannot connect to this slot because APWorld version is greater than mod version.",
+					"seed": "Cannot connect to this multiworld because this save was previously connected to a different multiworld.",
+					"slot": "Cannot connect to this slot because this save was previously connected to a different slot in this multiworld."
+				}
+			},
 			"text-client": {
 				"apConnection": "Modify connection details, disconnect, or reconnect.",
 				"apGameInfoMenu": "Check on important YAML options.",

--- a/src/patches/login.ts
+++ b/src/patches/login.ts
@@ -121,7 +121,7 @@ export function patch(plugin: MwRandomizer) {
 
 		hide(success) {
 			if (!success) {
-				sc.multiworld.client.socket.disconnect();
+				sc.multiworld.disconnect();
 			}
 			ig.interact.removeEntry(this.buttonInteract);
 			ig.interact.setBlockDelay(0.2);

--- a/src/patches/multiworld-model.ts
+++ b/src/patches/multiworld-model.ts
@@ -393,6 +393,8 @@ export function patch(plugin: MwRandomizer) {
 				ig.vars.setDefault("mw.mode", this.mode);
 				ig.vars.setDefault("mw.options", this.options);
 				ig.vars.setDefault("mw.dataPackageChecksums", this.dataPackageChecksums);
+				ig.vars.setDefault("mw.seed", this.client.room.seedName)
+				ig.vars.setDefault("mw.slot", this.client.players.self.slot)
 				ig.vars.set("mw.connectionInfo", this.connectionInfo);
 
 				for (let i = this.lastIndexSeen + 1; i < this.client.items.received.length; i++) {
@@ -463,6 +465,8 @@ export function patch(plugin: MwRandomizer) {
 			},
 
 			async login(info, mw, listener) {
+				this.disconnectPlanned = false;
+
 				const fatalError = (message: string) => {
 					listener.onLoginError(message);
 					this.updateConnectionStatus(sc.MULTIWORLD_CONNECTION_STATUS.DISCONNECTED);
@@ -516,14 +520,32 @@ export function patch(plugin: MwRandomizer) {
 						}
 					);
 
+					// semver is provided by CCModManager. don't wanna set up the typescript for this.
+					// @ts-ignore
+					if (slotData.apworldVersion && semver.gt(slotData.apworldVersion, plugin.mod.version)) {
+						fatalError("Cannot connect to this slot because APWorld version is greater than mod version.");
+						return;
+					}
+
 					listener.onLoginProgress("Checking local game package cache.");
 
 					// okay, if we actually successfully connected, we should have the roomInfo packet
 					// also, if we had any data packages cached, those should be available now
 					// in either case, we'll need all of that information for the next phase
 					// possibly the room info promise idles forever but there's no way that happens, right?
-					let [gamePackages, roomInfo] = await Promise.all([dataPackagePromise, roomInfoPromise]);
-					let remoteChecksums = roomInfo[0].datapackage_checksums;
+					let [gamePackages, [roomInfo]] = await Promise.all([dataPackagePromise, roomInfoPromise]);
+
+					if (mw?.seed && mw.seed !== roomInfo.seed_name) {
+						fatalError("Cannot connect to this multiworld because this save was previously connected to a different multiworld.");
+						return;
+					}
+
+					if (mw?.slot && mw.slot !== this.client.players.self.slot) {
+						fatalError("Cannot connect to this slot because this save was previously connected to a different slot in this multiworld.");
+						return;
+					}
+
+					let remoteChecksums = roomInfo.datapackage_checksums;
 					this.dataPackageChecksums = remoteChecksums;
 
 					// list of expected checksums, loaded from save file

--- a/src/patches/multiworld-model.ts
+++ b/src/patches/multiworld-model.ts
@@ -523,7 +523,7 @@ export function patch(plugin: MwRandomizer) {
 					// semver is provided by CCModManager. don't wanna set up the typescript for this.
 					// @ts-ignore
 					if (slotData.apworldVersion && semver.gt(slotData.apworldVersion, plugin.mod.version)) {
-						fatalError("Cannot connect to this slot because APWorld version is greater than mod version.");
+						fatalError(ig.lang.get("sc.gui.mw.login.failures.gen-version"));
 						return;
 					}
 
@@ -536,12 +536,12 @@ export function patch(plugin: MwRandomizer) {
 					let [gamePackages, [roomInfo]] = await Promise.all([dataPackagePromise, roomInfoPromise]);
 
 					if (mw?.seed && mw.seed !== roomInfo.seed_name) {
-						fatalError("Cannot connect to this multiworld because this save was previously connected to a different multiworld.");
+						fatalError(ig.lang.get("sc.gui.mw.login.failures.seed"));
 						return;
 					}
 
 					if (mw?.slot && mw.slot !== this.client.players.self.slot) {
-						fatalError("Cannot connect to this slot because this save was previously connected to a different slot in this multiworld.");
+						fatalError(ig.lang.get("sc.gui.mw.login.failures.slot"));
 						return;
 					}
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -44,6 +44,8 @@ if (!("structuredClone" in globalThis)) {
 	globalThis.structuredClone = structuredClone;
 }
 
+import { Mod } from 'ultimate-crosscode-typedefs/modloader/mod';
+
 declare global {
 	namespace ig.Input {
 		interface KnownActions {
@@ -56,11 +58,13 @@ declare global {
 }
 
 export default class MwRandomizer {
+	mod: Mod;
 	baseDirectory: string;
 	randoData!: WorldData;
 	itemdb: any;
 
-	constructor(mod: {baseDirectory: string}) {
+	constructor(mod: Mod) {
+		this.mod = mod;
 		this.baseDirectory = mod.baseDirectory;
 	}
 

--- a/src/types/multiworld-model.ts
+++ b/src/types/multiworld-model.ts
@@ -98,6 +98,8 @@ declare global {
 			export type MultiworldVars = {
 				connectionInfo: AnyConnectionInformation;
 				mode: "open" | "linear";
+				seed?: string;
+				slot?: number;
 				options: MultiworldOptions;
 				lastIndexSeen: number;
 				checkedLocations: number[];
@@ -110,6 +112,7 @@ declare global {
 
 			export type SlotData = {
 				mode: "open" | "linear";
+				apworldVersion?: string;
 				options: MultiworldOptions;
 			};
 		}


### PR DESCRIPTION
These commits add three checks to the login flow:
* was the world generated with a future version of the apworld?
* is the game's seed the same as the one this game was previously connected to?
* is the game's slot number the same as the on this game was previously connected to?

This also fixes an issue in the login flow where all but the first instance of disconnection from the login dialog pull up the "planned disconnect" GUI.