### PR TITLE
DLC Botanics Data

### DIFF
--- a/data/in/dlc/botanics.json
+++ b/data/in/dlc/botanics.json
@@ -1,0 +1,103 @@
+{
+	"botanics": {
+		"Alpha Cone Sprout": {
+			"location": {
+				"area": "final-dng",
+				"name": "Final-Plant-A"
+			},
+			"region": {
+				"open": "openDLC_DungeonEntry"
+			}
+		},
+		"Beta Cone Sprout": {
+			"location": {
+				"area": "final-dng",
+				"name": "Final-Plant-B"
+			},
+			"region": {
+				"open": "openDLC_DungeonEntry"
+			}
+		},
+		"Gamma Cone Sprout": {
+			"location": {
+				"area": "final-dng",
+				"name": "Final-Plant-C"
+			},
+			"region": {
+				"open": "openDLC_DungeonEntry"
+			}
+		},
+		"Delta Cone Sprout": {
+			"location": {
+				"area": "final-dng",
+				"name": "Final-Plant-D"
+			},
+			"region": {
+				"open": "openDLC_DungeonEntry"
+			}
+		},
+		"Alpha Shard": {
+			"location": {
+				"area": "final-dng",
+				"name": "Final-Planet-E"
+			},
+			"region": {
+				"open": "openDLC_DungeonEntry"
+			}
+		},
+		"Alpha Coral Blub": {
+			"location": {
+				"area": "beach",
+				"name": "Beach-Pink-1"
+			},
+			"region": {
+				"open": "openDLC_Beach"
+			}
+		},
+		"Beta Coral Bulb": {
+			"location": {
+				"area": "beach",
+				"name": "Beach-Pink-2"
+			},
+			"region": {
+				"open": "openDLC_Beach"
+			}
+		},
+		"Alpha Keen Sprout": {
+			"location": {
+				"area": "beach",
+				"name": "Beach-Green-1"
+			},
+			"region": {
+				"open": "openDLC_Beach"
+			}
+		},
+		"Beta Keen Sprout": {
+			"location": {
+				"area": "beach",
+				"name": "Beach-Green-2"
+			},
+			"region": {
+				"open": "openDLC_Beach"
+			}
+		},
+		"Alpha Fossil Stone": {
+			"location": {
+				"area": "beach",
+				"name": "Beach-Grey-1"
+			},
+			"region": {
+				"open": "openDLC_Beach"
+			}
+		},
+		"Beta Fossil Stone": {
+			"location": {
+				"area": "beach",
+				"name": "Beach-Grey-2"
+			},
+			"region": {
+				"open": "openDLC_Beach"
+			}
+		}
+	}
+}

--- a/data/in/dlc/master.json
+++ b/data/in/dlc/master.json
@@ -1,5 +1,6 @@
 {
 	"_includes": [
+		"botanics.json",
 		"chests.json",
 		"cutscenes.json",
 		"quests.json",
@@ -12,7 +13,7 @@
     "dungeons": [ "final-dng" ],
     "keyringItems": [ "Ku'lero Key" ],
 	"_global": {
-		"/cutscenes|chests|quests|regions|item-pools|shops/": {
+		"/botanics|cutscenes|chests|quests|regions|item-pools|shops/": {
 			"*": {
 				"metadata": {
 					"dlc": true


### PR DESCRIPTION
This PR adds eleven more plants corresponding to the Azure Archipelago and Ku'lero Temple Areas.

Reasoning:

* There is only one Beach Region, and I have assigned all of the beach plants to it.
* The Ku'lero cone flowers are plentiful in the entry region of Ku'lero temple.
* I am shaky on the placement of Shards. There are about ten shards in the entry region, so it should not be terrible to grind them, but it may need to be changed later. Requesting assistance on an appropriate region.

Requesting review from @kumquat-ir.