### PR TITLE
Another round of offline play fixes

### DIFF
--- a/src/patches/chest.ts
+++ b/src/patches/chest.ts
@@ -103,6 +103,10 @@ export function patch(plugin: MwRandomizer) {
 				return;
 			}
 
+			if (this.isOpen && !sc.multiworld.client.room.checkedLocations.includes(this.mwCheck.mwids[0])) {
+				sc.multiworld.reallyCheckLocation(this.mwCheck.mwids[0]);
+			}
+
 			if (this.rawChest.progression) {
 				// PROGRESSION items get a green chest
 				newOffY = 192;

--- a/src/patches/multiworld-model.ts
+++ b/src/patches/multiworld-model.ts
@@ -56,7 +56,6 @@ export function patch(plugin: MwRandomizer) {
 				// defineVarProperty(this, "options", "mw.options");
 				defineVarProperty(this, "progressiveChainProgress", "mw.progressiveChainProgress");
 				defineVarProperty(this, "receivedItemMap", "mw.received");
-				defineVarProperty(this, "offlineCheckBuffer", "mw.offlineCheckBuffer");
 
 				this.client.items.on("itemsReceived", (items: ap.Item[], index: number) => {
 					if (!ig.game.mapName || ig.game.mapName == "newgame" || !this.receivedItemMap) {
@@ -378,10 +377,6 @@ export function patch(plugin: MwRandomizer) {
 					};
 				}
 
-				if (!this.offlineCheckBuffer) {
-					this.offlineCheckBuffer = [];
-				}
-
 				if (!this.seenChests) {
 					this.seenChests = new Set();
 				}
@@ -403,11 +398,6 @@ export function patch(plugin: MwRandomizer) {
 				}
 
 				if (this.client.authenticated) {
-					if (this.offlineCheckBuffer.length > 0) {
-						this.client.check(...this.offlineCheckBuffer);
-						this.offlineCheckBuffer = [];
-					}
-
 					const mapName = ig.game.mapName;
 					const team = this.client.players.self.team;
 					const slot = this.client.players.self.slot;
@@ -432,7 +422,6 @@ export function patch(plugin: MwRandomizer) {
 
 				this.questSettings = null as any;
 				this.receivedItemMap = null as any;
-				this.offlineCheckBuffer = null as any;
 				this.seenChests = null as any;
 			},
 
@@ -448,8 +437,6 @@ export function patch(plugin: MwRandomizer) {
 			async reallyCheckLocation(mwid: number) {
 				if (this.client.authenticated) {
 					this.client.check(mwid);
-				} else {
-					this.offlineCheckBuffer.push(mwid);
 				}
 
 				let loc = this.locationInfo[mwid];
@@ -603,7 +590,23 @@ export function patch(plugin: MwRandomizer) {
 
 				sc.Model.notifyObserver(this, sc.MULTIWORLD_MSG.OPTIONS_PRESENT, this.options);
 
-				this.localCheckedLocations = new Set(mw?.checkedLocations);
+				// load the list of locations checked by the client from the variables (if we don't already have some)
+				if (!this.localCheckedLocations) {
+					this.localCheckedLocations = new Set(mw?.localCheckedLocations);
+				}
+				// create a set of locations checked on the server side
+				const remoteCheckedLocations = new Set(this.client.room.checkedLocations);
+				// get all locations checked on the client side that are not checked on the server side
+				let initialChecks: number[] = [];
+				for (const loc of this.localCheckedLocations) {
+					if (!remoteCheckedLocations.has(loc)) {
+						initialChecks.push(loc);
+					}
+				}
+				// if initial checks is not empty or nonexistent, then we have local progress to send
+				if (initialChecks !== undefined && initialChecks.length > 0) {
+					this.client.check(...initialChecks);
+				}
 
 				for (const location of this.client.room.checkedLocations) {
 					this.localCheckedLocations.add(location);

--- a/src/types/multiworld-model.ts
+++ b/src/types/multiworld-model.ts
@@ -102,10 +102,9 @@ declare global {
 				slot?: number;
 				options: MultiworldOptions;
 				lastIndexSeen: number;
-				checkedLocations: number[];
+				localCheckedLocations: number[];
 				progressiveChainProgress: Record<number, number>;
 				locationInfo: Record<number, LocalInternalItem>;
-				offlineCheckBuffer: number[];
 				dataPackageChecksums: Record<string, string>;
 				seenChests: number[];
 			};
@@ -141,7 +140,6 @@ declare global {
 			locationInfo: {[idx: number]: ap.Item};
 			connectionInfo: sc.MultiWorldModel.ConnectionInformation;
 			localCheckedLocations: Set<number>;
-			offlineCheckBuffer: number[];
 			mode: string;
 			options: sc.MultiWorldModel.MultiworldOptions;
 			progressiveChainProgress: Record<number, number>;


### PR DESCRIPTION
This gets rid of the offlineCheckBuffer, which was typically inaccurate, instead opting to send the difference between localCheckedLocations and client.room.checkedLocations on login.

This works based on my anecdotal testing.