### PR TITLE
0.8.3 Logic Fixes

### DIFF
--- a/data/in/regions.json
+++ b/data/in/regions.json
@@ -573,7 +573,7 @@
 					]
 				},
 				{
-					"from": "open15.2",
+					"from": "open15.1",
 					"to": "open15.3",
 					"condition": [
 						[ "item", "Kajo Master Key", 1 ]


### PR DESCRIPTION
Any and all logic bugs that need to be addressed in the 0.8 branch will go here.

Currently:
* move Krys'kajo final boss before keys ([reported here](https://discord.com/channels/1145762453658026104/1489318573594906916))