### PR TITLE
Fix Goat Zira's shop logic

### DIFF
--- a/data/in/dlc/shops.json
+++ b/data/in/dlc/shops.json
@@ -75,7 +75,10 @@
                 "Just Water",
                 "Goat Cheese",
                 "Goat Milk"
-			]
+			],
+            "metadata": {
+                "quest": true
+            }
 		},
 		"Rhombus Weapons + DLC": {
 			"location": {


### PR DESCRIPTION
It requires completing two entire quest chains to access, so we need to mark it as such to avoid putting it in logic with quest rando off and forcing people to do quests when they don't want to
(or we could change the requirements for the shop to spawn, but I don't think there's any non-quest requirements that would make much sense)

See also:
https://github.com/CodeTriangle/Archipelago/pull/20