### PR TITLE
allow botanics to be sent at any point after collecting the drops

### DIFF
--- a/src/patches/botanics.ts
+++ b/src/patches/botanics.ts
@@ -25,11 +25,10 @@ export function patch(plugin: MwRandomizer) {
 		},
 
 		incrementDropCount(drop, anim) {
-			const completedBefore = sc.menu.dropCounts[drop]?.completed ?? false;
 			this.parent(drop, anim);
-			const completedAfter = sc.menu.dropCounts[drop]?.completed ?? false;
-			if (!completedBefore && completedAfter) {
-				const mwid = sc.randoData.botanics[drop];
+			const completed = sc.menu.dropCounts[drop]?.completed ?? false;
+			const mwid = sc.randoData.botanics[drop];
+			if (completed && !sc.multiworld.localCheckedLocations.has(mwid)) {
 				sc.multiworld.reallyCheckLocation(mwid);
 			}
 		},


### PR DESCRIPTION
should fix edge cases with the completion of the botanics not being detected