### PR TITLE
fix reconnect resending all checks

### DIFF
--- a/src/patches/multiworld-model.ts
+++ b/src/patches/multiworld-model.ts
@@ -417,6 +417,7 @@ export function patch(plugin: MwRandomizer) {
 				this.connectionInfo = null as any;
 				this.mode = null as any;
 				this.options = null as any;
+				this.localCheckedLocations = null as any;
 
 				this.dataPackageChecksums = null as any;
 


### PR DESCRIPTION
Fix a critical issue where disconnecting from a server then reconnecting to another server would send all of the locations from the first server to the second.