### PR TITLE
Chest viewer option

### DIFF
--- a/src/patches/map.ts
+++ b/src/patches/map.ts
@@ -52,7 +52,7 @@ export function patch(plugin: MwRandomizer) {
 
 				let isSeen = sc.multiworld.seenChests.has(info.mwid);
 
-				if (!isSeen || sc.multiworld.options.chestReveal == true) {
+				if (isSeen || sc.multiworld.options.chestReveal == true) {
 					if (loc.progression) {
 						this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.progression);
 					} else if (loc.useful || loc.trap) {

--- a/src/patches/map.ts
+++ b/src/patches/map.ts
@@ -52,9 +52,7 @@ export function patch(plugin: MwRandomizer) {
 
 				let isSeen = sc.multiworld.seenChests.has(info.mwid);
 
-				if (!isSeen) {
-					this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.unknown);
-				} else {
+				if (!isSeen || sc.multiworld.options.chestReveal == true) {
 					if (loc.progression) {
 						this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.progression);
 					} else if (loc.useful || loc.trap) {
@@ -62,6 +60,8 @@ export function patch(plugin: MwRandomizer) {
 					} else {
 						this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.filler);
 					}
+				} else {
+					this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.unknown);
 
 					let clearance = (info as MarkerInfo<"Chest">).settings.defaultClearance;
 

--- a/src/patches/map.ts
+++ b/src/patches/map.ts
@@ -60,8 +60,6 @@ export function patch(plugin: MwRandomizer) {
 					} else {
 						this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.filler);
 					}
-				} else {
-					this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.unknown);
 
 					let clearance = (info as MarkerInfo<"Chest">).settings.defaultClearance;
 
@@ -72,6 +70,8 @@ export function patch(plugin: MwRandomizer) {
 							sc.MULTIWORLD_MARKER_ICON_COORDS["rim-" + clearance.toLowerCase()]
 						);
 					}
+				} else {
+					this.addMarkerIcon(sc.MULTIWORLD_MARKER_ICON_COORDS.unknown);
 				}
 			}
 		},

--- a/src/types/multiworld-model.ts
+++ b/src/types/multiworld-model.ts
@@ -93,6 +93,7 @@ declare global {
 				shopReceiveMode?: string,
 				shopDialogHints?: boolean,
 				chestClearanceLevels?: Record<number, keyof typeof sc.CHEST_TYPE>,
+				chestReveal: boolean,
 				botanicsCompletionAmount?: number,
 			};
 


### PR DESCRIPTION
Putting in an additional condition option to show the categories of chests without having to reach the room first. Made it as a YAML setting. I wanted to run crosscode in average length syncs(3-5 hours) and having the ability to see what chests are worth going for before you even reach the room can help save a lot of time from the run.

Tested it on a local-made build with these changes and works as expected, with the default off setting being the same as before this change.