### PR TITLE
Everlasting Amber typo fix

### DIFF
--- a/data/in/items.json
+++ b/data/in/items.json
@@ -580,7 +580,7 @@
 		},
 		"Everlasting Amber": {
 			"id": 183,
-            "classificaton": "progression"
+            "classification": "progression"
 		},
 		"Weird Hillkat Tech": {
 			"id": 184


### PR DESCRIPTION
Fix the typo causing gen errors because Everlasting Amber was not progression.