### PR TITLE
make bundle script write in ordered chunks

### DIFF
--- a/bundle.mjs
+++ b/bundle.mjs
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import { createWriteStream } from "node:fs"; 
 import * as process from "node:process";
 import * as fflate from "fflate";
 
@@ -34,17 +35,22 @@ if (process.argv.length > 2) {
 }
 
 const filename = `CCMultiworldRandomizer-${versionString}.ccmod`;
-const outfile = await fs.open(filename, "w");
+const outfile = createWriteStream(filename);
 
-const zipfile = new fflate.Zip((err, data, final) => {
-	if (err) {
-		console.error(err);
-		return;
-	}
-	outfile.write(data);
-	if (final) {
-		outfile.close();
-	}
+const zipfile = new fflate.Zip();
+
+const finishedPromise = new Promise((res, rej) => {
+	zipfile.ondata = (err, data, final) => {
+		if (err) {
+			console.error(err);
+			rej(err);
+		}
+		outfile.write(data);
+		if (final) {
+			outfile.close();
+			res();
+		}
+	};
 });
 
 for (const path of files) {
@@ -74,3 +80,5 @@ for (const dir of directories) {
 }
 
 zipfile.end();
+
+await finishedPromise;

--- a/bundle.mjs
+++ b/bundle.mjs
@@ -37,20 +37,15 @@ if (process.argv.length > 2) {
 const filename = `CCMultiworldRandomizer-${versionString}.ccmod`;
 const outfile = createWriteStream(filename);
 
-const zipfile = new fflate.Zip();
-
-const finishedPromise = new Promise((res, rej) => {
-	zipfile.ondata = (err, data, final) => {
-		if (err) {
-			console.error(err);
-			rej(err);
-		}
-		outfile.write(data);
-		if (final) {
-			outfile.close();
-			res();
-		}
-	};
+const zipfile = new fflate.Zip((err, data, final) => {
+	if (err) {
+		console.error(err);
+		return;
+	}
+	outfile.write(data);
+	if (final) {
+		outfile.close();
+	}
 });
 
 for (const path of files) {
@@ -80,5 +75,3 @@ for (const dir of directories) {
 }
 
 zipfile.end();
-
-await finishedPromise;


### PR DESCRIPTION
`fflate` passes you data in chunks of a few bytes to a few kilobytes, which you write to your file. On calling `outfile.write(data)`, it initiates a promise to write that data but does not do so yet. If you call `outfile.write` again while that promise is unresolved, then there is no guarantee that the first promise to be submitted will be the first to be written. It usually will but that can't be guaranteed. The fix is to use `createWriteStream` to make an ordered write buffer.
