### PR TITLE
Move Creator goal to Vermillion Wasteland

### DIFF
--- a/data/in/regions.json
+++ b/data/in/regions.json
@@ -620,7 +620,7 @@
 			"start": "open2",
 			"goals": {
 				"creator": {
-					"region": "open16.1",
+					"region": "open18",
 					"condition": [
 						[ "item", "Heat", 1 ],
 						[ "item", "Cold", 1 ],


### PR DESCRIPTION
The Creator goal is currently placed in region `open16.1` (the north of Sapphire Ridge) instead of `open18` (Vermillion Wasteland). This makes it so the logic will always require the Meteor Shade even with Vermillion Wasteland Meteor Passage disabled. It's not an actual issue currently, and I doubt it will ever be, but it might as well be fixed.