### PR TITLE
Fix regions for shock pedestal, So'najiz circuit override

### DIFF
--- a/data/in/cutscenes.json
+++ b/data/in/cutscenes.json
@@ -300,7 +300,7 @@
 			},
 			"region": {
 				"linear": "27",
-				"open": "open14.4" 
+				"open": "open14.5"
 			},
 			"reward": [
 				[ "item", "Circuit Override", 1 ]

--- a/data/in/elements.json
+++ b/data/in/elements.json
@@ -36,7 +36,7 @@
 			},
 			"region": {
 				"linear": "27",
-				"open": "open14.5"
+				"open": "open14.4"
 			},
 			"reward": [
 				["element", "Shock"]


### PR DESCRIPTION
open14.4 is the region for the shock pedestal (after the final locked gate in trial of persistence), open14.5 is the region for the end of the dungeon, requiring shock