### PR TITLE
Add metadata to dlc region connections

### DIFF
--- a/data/in/dlc/master.json
+++ b/data/in/dlc/master.json
@@ -19,6 +19,17 @@
 					"dlc": true
 				}
 			}
+		},
+		"regions": {
+			"*": {
+				"connections": {
+					"*": {
+						"metadata": {
+							"dlc": true
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is to support CodeTriangle/Archipelago#26.